### PR TITLE
adds a falz-mark to the exported letter.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -33,3 +33,5 @@ The generator is splited in two parts:
 To generate letter, compile the data-file via asciidoctor.
 
 To handle the files in there directories you can use the script-file
+
+The file `falz.svg` contains an image which gives you hints where to falz your letter so you can put it into an envelop.

--- a/data/falz.svg
+++ b/data/falz.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="210mm"
+   height="297mm"
+   viewBox="0 0 210 297"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25)"
+   sodipodi:docname="drawing.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="1.1893044"
+     inkscape:cx="134.11201"
+     inkscape:cy="623.47369"
+     inkscape:window-width="1312"
+     inkscape:window-height="946"
+     inkscape:window-x="1918"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="fill:#000100;fill-opacity:1;stroke-width:0.466252;stroke-linejoin:round;stroke-miterlimit:10;paint-order:markers stroke fill"
+       id="rect1"
+       width="11.790856"
+       height="1.1123449"
+       x="0.47515491"
+       y="198.78358"
+       inkscape:transform-center-x="1.1123449"
+       inkscape:transform-center-y="-0.096725658" />
+    <rect
+       style="fill:#000000;stroke-width:0.466252;stroke-linejoin:round;stroke-miterlimit:10;paint-order:markers stroke fill;fill-opacity:1"
+       id="rect1-9"
+       width="11.790856"
+       height="1.1123449"
+       x="0.18035483"
+       y="99.685059"
+       inkscape:transform-center-x="1.1123449"
+       inkscape:transform-center-y="-0.096725658" />
+  </g>
+</svg>

--- a/data/letter-main.adoc
+++ b/data/letter-main.adoc
@@ -17,6 +17,7 @@ ASCIIDOC
 
 include::letter-content-temp.adoc[lines=1..20]
 
+:page-background-image: image:falz.svg[]
 //-----------------------------------------------------------------------------------------
 
 {empty} +


### PR DESCRIPTION
An example where to put the falzmarken. Idea is to use falzmarken as a background image. Maybe some fine-tuning is required. Because the marks might be a little bit to thick or not black enough. Just change it with inkscape. 